### PR TITLE
avoid using size of non-static data member

### DIFF
--- a/include/eixx/marshal/ref.hpp
+++ b/include/eixx/marshal/ref.hpp
@@ -200,7 +200,7 @@ public:
 
     bool operator==(const ref<Alloc>& t) const {
         return node() == t.node() &&
-               ::memcmp(&m_blob->data()->u, &t.m_blob->data()->u, sizeof(ref_blob::u)) == 0;
+               ::memcmp(&m_blob->data()->u, &t.m_blob->data()->u, sizeof(&m_blob->data()->u)) == 0;
     }
 
     /// Less operator, needed for maps


### PR DESCRIPTION
sizeof non-static data member doesnt't compile with clang for some reason. This change is not enough to compile eixx with clang, but now it is possible to use eixx headers in project that builds with clang.
Fixes #4
