### PR TITLE
Handle UB in bit_scan_forward

### DIFF
--- a/include/eixx/connect/transport_msg.hpp
+++ b/include/eixx/connect/transport_msg.hpp
@@ -108,7 +108,7 @@ public:
 
     /// Transport message type
     transport_msg_type  type()      const { return m_type; }
-    int                 to_type()   const { return bit_scan_forward(m_type); }
+    int                 to_type()   const { return m_type == UNDEFINED ? 0 : bit_scan_forward(m_type); }
     const tuple<Alloc>& cntrl()     const { return m_cntrl;}
     const eterm<Alloc>& msg()       const { return m_msg;  }
     /// Returns true when the transport message contains message payload

--- a/include/eixx/util/common.hpp
+++ b/include/eixx/util/common.hpp
@@ -74,7 +74,8 @@ int __inline__ log2(unsigned long n, uint8_t base = 2) {
     return n == 1 ? 0 : 1+log2(n/base, base); 
 }
 
-static __inline__ unsigned long bit_scan_forward(unsigned long v)
+/// Note, that bit_scan_forward(0) leads to UB
+static __inline__ int bit_scan_forward(unsigned long v)
 {
     return __builtin_ctzl(v);
 }


### PR DESCRIPTION
Commit 37ece8e0068c2dc523443d7a0cbfb541852d5197 introduced UB into bit_scan_forward
when called with zero agrument.

Check m_type == UNDEFINED explicitly in to_type()
Also replace bit_scan_forward return type to int to avoid double conversion.