### PR TITLE
Fix bug - uninitialized cons node field

### DIFF
--- a/include/eixx/marshal/list.hxx
+++ b/include/eixx/marshal/list.hxx
@@ -190,7 +190,7 @@ void list<Alloc>::push_back(const eterm<Alloc>& a)
         hd->size = 1;
         hd->alloc_size = 1;
         cons_t* p = hd->tail;
-        p->node.set(a);
+        new (&p->node) eterm<Alloc>(a);
         p->next = NULL;
         return;
     }


### PR DESCRIPTION
The bug resulted in memory segmentation failure when adding an element into the eixx::list constructed with no arguments.