### PR TITLE
Do not rely on a past guess about encoding size

### DIFF
--- a/include/eixx/marshal/visit_encode_size.hpp
+++ b/include/eixx/marshal/visit_encode_size.hpp
@@ -38,8 +38,8 @@ template <typename Alloc>
 struct visit_eterm_encode_size_calc
     : public static_visitor<visit_eterm_encode_size_calc<Alloc>, size_t> {
 
-    size_t operator()(bool   a) const { return 3 + (a ? 4 : 5); }
-    size_t operator()(double a) const { return 9; }
+    size_t operator()(bool   a) const { int n = 0; ei_encode_boolean(NULL, &n, a); return n; }
+    size_t operator()(double a) const { int n = 0; ei_encode_double(NULL, &n, a); return n; }
     size_t operator()(long   a) const { int n = 0; ei_encode_longlong(NULL, &n, a); return n; }
 
     template <typename T>


### PR DESCRIPTION
This at least didn't work with Erlang/OTP 23, tested with erlang-jinterface-23.2.3-1.el7.x86_64 from Erlang Solutions, where boolean encoded size was 1 byte less than old code expected.