### PR TITLE
Fix build for darwin (macOS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,12 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/build-aux/CMakeEx.txt)
 #-------------------------------------------------------------------------------
 # See also build/CMakeInit.txt
 if("${toolchain}" STREQUAL "gcc")
-  set(CMAKE_C_COMPILER   "gcc")
-  set(CMAKE_CXX_COMPILER "g++")
+  if(NOT CMAKE_C_COMPILER)
+    set(CMAKE_C_COMPILER   "gcc")
+  endif()
+  if(NOT CMAKE_CXX_COMPILER)
+    set(CMAKE_CXX_COMPILER "g++")
+  endif()
   add_definitions(-fopenmp -Wall -Wno-strict-aliasing)
 
   if("${CMAKE_BUILD_TYPE}" STREQUAL "release")
@@ -185,7 +189,10 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pc.in"
 #-------------------------------------------------------------------------------
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/src)
-add_subdirectory(${CMAKE_SOURCE_DIR}/test)
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR
+   CMAKE_SYSTEM_NAME STREQUAL Android)
+  add_subdirectory(${CMAKE_SOURCE_DIR}/test)
+endif()
 
 #===============================================================================
 # Installation

--- a/build-aux/bootstrap.mk
+++ b/build-aux/bootstrap.mk
@@ -6,9 +6,9 @@
 # Date: 2014-08-12
 #-------------------------------------------------------------------------------
 
-PROJECT  := $(shell sed -n '/^project/{s/^project. *\([a-zA-Z0-9]\+\).*/\1/p; q}'\
+PROJECT  := $(shell sed -n '/^project/{s/^project. *\([a-zA-Z0-9]\{1,\}\).*/\1/p; q;}'\
                     CMakeLists.txt)
-VERSION  := $(shell sed -n '/^project/{s/^.\+VERSION \+//; s/[^\.0-9]\+//; p; q}'\
+VERSION  := $(shell sed -n '/^project/{s/^.\{1,\}VERSION \{1,\}//; s/[^\.0-9]\{1,\}//; p; q;}'\
                     CMakeLists.txt)
 
 HOSTNAME := $(shell hostname)
@@ -61,11 +61,7 @@ endif
 
 # Function that replaces variables in a given entry in a file 
 # E.g.: $(call substitute,ENTRY,FILENAME)
-substitute   = $(shell sed -n '/^$(1)=/{s!$(1)=!!; s!/\+$$!!;     \
-                                       s!@PROJECT@!$(PROJECT)!gI; \
-                                       s!@VERSION@!$(VERSION)!gI; \
-                                       s!@BUILD@!$(BUILD)!gI;     \
-                                       p; q}' $(2) 2>/dev/null)
+substitute   = $(shell sed -n '/^$(1)=/{s!$(1)=!!; s!/\{1,\}$$!!; s!@PROJECT@!$(PROJECT)!g; s!@VERSION@!$(VERSION)!g; s!@BUILD@!$(BUILD)!g; p; q;}' $(2) 2>/dev/null)
 BLD_DIR     := $(call substitute,DIR:BUILD,$(OPT_FILE))
 ROOT_DIR    := $(dir $(abspath include))
 DEF_BLD_DIR := $(ROOT_DIR:%/=%)/build
@@ -95,8 +91,8 @@ ver:
 variables   := $(filter-out toolchain=% generator=% build=% verbose=% prefix=%,$(MAKEOVERRIDES))
 makevars    := $(variables:%=-D%)
 
-envvars     += $(shell sed -n '/^ENV:/{s/^ENV://;p}' $(OPT_FILE) 2>/dev/null)
-makevars    += $(patsubst %,-D%,$(shell sed -n '/^...:/!{s/ *\#.*$$//; /^$$/!p}' \
+envvars     += $(shell sed -n '/^ENV:/{s/^ENV://;p;}' $(OPT_FILE) 2>/dev/null)
+makevars    += $(patsubst %,-D%,$(shell sed -n '/^...:/!{s/ *\#.*$$//; /^$$/!p;}' \
                                             $(OPT_FILE) 2>/dev/null))
 
 makecmd      = $(envvars) cmake -H. -B$(DIR) \


### PR DESCRIPTION
Support building on Darwin/BSD.

Build of test are skipped due to these errors:
- `test/test_perf.cpp:23:30`: error 'RUSAGE_THREAD' was not declared in this scope
- `test/test_eterm.cpp:36:43`: error: no matching function for call to 'eixx::marshal::eterm<boost::fast_pool_allocator<char, boost::default_user_allocator_new_delete, boost::details::pool::null_mutex> >::get<size_t>()'

'RUSAGE_THREAD' has no equivalent on Darwin.