### PR TITLE
Support Boost v1.66+ and OTP v20 to v22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,9 +122,7 @@ set(Boost_USE_MULTITHREAD ON)
 set(Boost_NO_SYSTEM_PATHS ON)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/build")
 
-find_package(Boost 1.55.0 REQUIRED COMPONENTS
-             system filesystem date_time program_options thread regex
-             unit_test_framework timer)
+find_package(Boost 1.55.0 REQUIRED COMPONENTS system thread)
 
 if(Boost_FOUND)
   #include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
@@ -132,16 +130,6 @@ if(Boost_FOUND)
   set(UTXX_HAVE_BOOST_TIMER_TIMER_HPP 1)
 	message(STATUS "Found boost: ${Boost_LIBRARY_DIRS}")
 endif()
-
-set(Boost_LIBRARIES
-  boost_system
-  boost_thread
-# ${Boost_REGEX_LIBRARY}
-# ${Boost_DATE_TIME_LIBRARY}
-# ${Boost_FILESYSTEM_LIBRARY}
-#  ${Boost_PROGRAM_OPTIONS_LIBRARY}
-#  ${Boost_IOSTREAMS_LIBRARY}
-)
 
 #-------------------------------------------------------------------------------
 # Platform-specific checks

--- a/include/eixx/connect/basic_otp_mailbox.hpp
+++ b/include/eixx/connect/basic_otp_mailbox.hpp
@@ -101,7 +101,7 @@ public:
     template<typename T, typename A> friend struct util::async_queue;
     template<typename A, typename M> friend class basic_otp_mailbox_registry;
     template<typename _R> friend class std::function;
-    template<typename _R, typename _F> friend class std::_Function_handler;
+    // template<typename _R, typename _F> friend class std::_Function_handler;
 
 private:
     boost::asio::io_service&            m_io_service;

--- a/include/eixx/connect/transport_msg.hpp
+++ b/include/eixx/connect/transport_msg.hpp
@@ -450,8 +450,9 @@ const char* transport_msg<Alloc>::type_string() const {
         case DEMONITOR_P:       return "DEMONITOR_P";
         case MONITOR_P_EXIT:    return "MONITOR_P_EXIT";
         default: {
-            std::stringstream str; str << "UNSUPPORTED(" << bit_scan_forward(m_type) << ')';
-            return str.str().c_str();
+            // std::stringstream str; str << "UNSUPPORTED(" << bit_scan_forward(m_type) << ')';
+            // return str.str().c_str();
+            return "UNSUPPORTED";
         }
     }
 }

--- a/include/eixx/connect/transport_otp_connection.hxx
+++ b/include/eixx/connect/transport_otp_connection.hxx
@@ -44,7 +44,7 @@ template <class Handler, class Alloc>
 const size_t connection<Handler, Alloc>::s_header_size = 4;
 
 template <class Handler, class Alloc>
-const char   connection<Handler, Alloc>::s_header_magic = 132;
+const char   connection<Handler, Alloc>::s_header_magic = static_cast<char>(132);
 
 template <class Handler, class Alloc>
 const eterm<Alloc> connection<Handler, Alloc>::s_null_cookie;
@@ -172,7 +172,7 @@ handle_write(const boost::system::error_code& err)
         return;
     }
 
-    if (unlikely(err)) {
+    if (unlikely(bool(err))) {
         if (verbose() >= VERBOSE_TRACE) {
             std::stringstream s;
             s << "connection::handle_write(" << err.value() << ')';
@@ -223,7 +223,7 @@ handle_read(const boost::system::error_code& err, size_t bytes_transferred)
                 "Connection aborted - exiting connection::handle_read");
         }
         return;
-    } else if (unlikely(err)) {
+    } else if (unlikely(bool(err))) {
         // We use operation_aborted as a user-initiated connection reset,
         // therefore check to substitute the error since bytes_transferred == 0
         // means a connection loss.

--- a/include/eixx/connect/transport_otp_connection_tcp.hpp
+++ b/include/eixx/connect/transport_otp_connection_tcp.hpp
@@ -62,7 +62,13 @@ static const int   DFLAG_DIST_MONITOR           = 8;
 static const int   DFLAG_FUN_TAGS               = 16;
 static const int   DFLAG_NEW_FUN_TAGS           = 0x80;
 static const int   DFLAG_EXTENDED_PIDS_PORTS    = 0x100;
+static const int   DFLAG_EXPORT_PTR_TAG         = 0x200;
+static const int   DFLAG_BIT_BINARIES           = 0x400;
 static const int   DFLAG_NEW_FLOATS             = 0x800;
+static const int   DFLAG_SMALL_ATOM_TAGS        = 0x4000;
+static const int   DFLAG_UTF8_ATOMS             = 0x10000;
+static const int   DFLAG_MAP_TAG                = 0x20000;
+static const int   DFLAG_BIG_CREATION           = 0x40000;
 #endif
 
 //----------------------------------------------------------------------------
@@ -100,7 +106,13 @@ public:
         return s.str();
     }
 
-    int native_socket() { return m_socket.native(); }
+    int native_socket() {
+#if BOOST_VERSION >= 104700
+        return m_socket.native_handle();
+#else
+        return m_socket.native();
+#endif
+    }
 
 private:
     /// Authentication state
@@ -141,7 +153,7 @@ private:
 
     boost::shared_ptr<tcp_connection<Handler, Alloc> > shared_from_this() {
         boost::shared_ptr<connection<Handler, Alloc> > p = base_t::shared_from_this();
-        return *reinterpret_cast<boost::shared_ptr<tcp_connection<Handler, Alloc> >*>(&p);
+        return boost::reinterpret_pointer_cast<tcp_connection<Handler, Alloc> >(p);
     }
 
     /// Set the socket to non-blocking mode and issue on_connect() callback.

--- a/include/eixx/connect/transport_otp_connection_uds.hpp
+++ b/include/eixx/connect/transport_otp_connection_uds.hpp
@@ -59,8 +59,12 @@ public:
     boost::asio::local::stream_protocol::socket& socket() { return m_socket; }
 
     void start() {
+#if BOOST_VERSION >= 104700
+        m_socket.non_blocking(true);
+#else
         boost::asio::local::stream_protocol::socket::non_blocking_io nb(true);
         m_socket.io_control(nb);
+#endif
         base_t::start();
     }
 
@@ -70,7 +74,13 @@ public:
         return m_uds_filename;
     }
 
-    int native_socket() { return m_socket.native(); }
+    int native_socket() {
+#if BOOST_VERSION >= 104700
+        return m_socket.native_handle();
+#else
+        return m_socket.native();
+#endif
+    }
 
 private:
     /// Socket for the connection.

--- a/include/eixx/eixx.hpp
+++ b/include/eixx/eixx.hpp
@@ -59,9 +59,7 @@ limitations under the License.
 #endif
 
 #include <eixx/eterm.hpp>
-#if BOOST_VERSION < 106000
 #include <eixx/connect.hpp>
-#endif
 
 #endif // _EIXX_HPP_
 

--- a/include/eixx/marshal/atom.hpp
+++ b/include/eixx/marshal/atom.hpp
@@ -115,7 +115,7 @@ public:
 
     /// Get atom length from a binary buffer encoded in 
     /// Erlang external binary format.
-    static int getLen(const char*& s) {
+    static int get_len(const char*& s) {
         switch (get8(s)) {
 #ifdef ERL_SMALL_ATOM_UTF8_EXT
             case ERL_SMALL_ATOM_UTF8_EXT: return get8(s);
@@ -174,7 +174,7 @@ public:
     {
         const char *s = a_buf + idx;
         const char *s0 = s;
-        int len = getLen(s);
+        int len = get_len(s);
         if (len < 0)
             throw err_decode_exception("Error decoding atom", idx);
         m_index = atom_table().lookup(std::string(s, len));

--- a/include/eixx/marshal/atom.hpp
+++ b/include/eixx/marshal/atom.hpp
@@ -113,6 +113,25 @@ public:
         return create(std::string(s), existing);
     }
 
+    /// Get atom length from a binary buffer encoded in 
+    /// Erlang external binary format.
+    static int getLen(const char*& s) {
+        switch (get8(s)) {
+#ifdef ERL_SMALL_ATOM_UTF8_EXT
+            case ERL_SMALL_ATOM_UTF8_EXT: return get8(s);
+#endif
+#ifdef ERL_ATOM_UTF8_EXT
+            case ERL_ATOM_UTF8_EXT:       return get16be(s);
+#endif
+#ifdef ERL_SMALL_ATOM_EXT
+            case ERL_SMALL_ATOM_EXT:      return get8(s);
+#endif
+            case ERL_ATOM_EXT:            return get16be(s);
+            default:
+                return -1;
+        }
+    }
+
     /// @copydoc atom::atom
     /// @param existing    if true, check that the atom already exists, otherwise throw
     ///                    err_atom_not_found
@@ -155,14 +174,9 @@ public:
     {
         const char *s = a_buf + idx;
         const char *s0 = s;
-        int len;
-        switch (get8(s)) {
-            case ERL_ATOM_UTF8_EXT:       len = get16be(s);  break;
-            case ERL_SMALL_ATOM_UTF8_EXT: len = get8(s);     break;
-            case ERL_ATOM_EXT:            len = get16be(s);  break;
-            case ERL_SMALL_ATOM_EXT:      len = get8(s);     break;
-            default: throw err_decode_exception("Error decoding atom", idx);
-        }
+        int len = getLen(s);
+        if (len < 0)
+            throw err_decode_exception("Error decoding atom", idx);
         m_index = atom_table().lookup(std::string(s, len));
         idx += s + len - s0;
         BOOST_ASSERT((size_t)idx <= a_size);

--- a/include/eixx/marshal/eterm.hxx
+++ b/include/eixx/marshal/eterm.hxx
@@ -235,6 +235,15 @@ void eterm<Alloc>::decode(const char* a_buf, int& idx, size_t a_size, const Allo
         throw err_decode_exception("Cannot determine term type", idx);
 
     switch (type) {
+#ifdef ERL_ATOM_UTF8_EXT
+    case ERL_ATOM_UTF8_EXT:
+#endif
+#ifdef ERL_SMALL_ATOM_UTF8_EXT
+    case ERL_SMALL_ATOM_UTF8_EXT:
+#endif
+#ifdef ERL_SMALL_ATOM_EXT
+    case ERL_SMALL_ATOM_EXT:
+#endif
     case ERL_ATOM_EXT: {
         int b;
         int i = idx; // TODO: Eliminate this variable when there's is a fix for the bug in ei_decode_boolean

--- a/include/eixx/marshal/pid.hxx
+++ b/include/eixx/marshal/pid.hxx
@@ -40,7 +40,7 @@ void epid<Alloc>::decode(const char *buf, int& idx, size_t size, const Alloc& al
     if (get8(s) != ERL_PID_EXT)
         throw err_decode_exception("Error decoding pid", -1);
 
-    int len = atom::getLen(s);
+    int len = atom::get_len(s);
     if (len < 0)
         throw err_decode_exception("Error decoding pid node", -1);
     detail::check_node_length(len);

--- a/include/eixx/marshal/pid.hxx
+++ b/include/eixx/marshal/pid.hxx
@@ -39,11 +39,10 @@ void epid<Alloc>::decode(const char *buf, int& idx, size_t size, const Alloc& al
     const char* s0 = s;
     if (get8(s) != ERL_PID_EXT)
         throw err_decode_exception("Error decoding pid", -1);
-    auto n = get8(s);
-    if (n != ERL_ATOM_UTF8_EXT && n != ERL_ATOM_EXT)
-        throw err_decode_exception("Error decoding pid node", -1);
 
-    int len = get16be(s);
+    int len = atom::getLen(s);
+    if (len < 0)
+        throw err_decode_exception("Error decoding pid node", -1);
     detail::check_node_length(len);
 
     atom l_node(s, len);

--- a/include/eixx/marshal/port.hxx
+++ b/include/eixx/marshal/port.hxx
@@ -39,10 +39,10 @@ port<Alloc>::port(const char *buf, int& idx, size_t size, const Alloc& a_alloc)
     const char* s0 = s;
     if (get8(s) != ERL_PORT_EXT)
         throw err_decode_exception("Error decoding port", -1);
-    auto n  = get8(s);
-    if (n != ERL_ATOM_UTF8_EXT && n != ERL_ATOM_EXT)
+
+    int len = atom::getLen(s);
+    if (len < 0)
         throw err_decode_exception("Error decoding port node", -1);
-    int len = get16be(s);
     detail::check_node_length(len);
     atom l_node(s, len);
     s += len;

--- a/include/eixx/marshal/port.hxx
+++ b/include/eixx/marshal/port.hxx
@@ -40,7 +40,7 @@ port<Alloc>::port(const char *buf, int& idx, size_t size, const Alloc& a_alloc)
     if (get8(s) != ERL_PORT_EXT)
         throw err_decode_exception("Error decoding port", -1);
 
-    int len = atom::getLen(s);
+    int len = atom::get_len(s);
     if (len < 0)
         throw err_decode_exception("Error decoding port node", -1);
     detail::check_node_length(len);

--- a/include/eixx/marshal/ref.hxx
+++ b/include/eixx/marshal/ref.hxx
@@ -46,11 +46,10 @@ ref<Alloc>::ref(const char* buf, int& idx, size_t size, const Alloc& a_alloc)
             int count = get16be(s);
             if (count != COUNT)
                 throw err_decode_exception("Error decoding ref's count", idx+1);
-            auto n = get8(s);
-            if (n != ERL_ATOM_UTF8_EXT && n != ERL_ATOM_EXT)
-                throw err_decode_exception("Error decoding ref's atom", idx+3);
 
-            int len = get16be(s);
+            int len = atom::getLen(s);
+            if (len < 0)
+                throw err_decode_exception("Error decoding ref's atom", idx+3);
             detail::check_node_length(len);
             atom l_node(s, len);
             s += len;

--- a/include/eixx/marshal/ref.hxx
+++ b/include/eixx/marshal/ref.hxx
@@ -47,7 +47,7 @@ ref<Alloc>::ref(const char* buf, int& idx, size_t size, const Alloc& a_alloc)
             if (count != COUNT)
                 throw err_decode_exception("Error decoding ref's count", idx+1);
 
-            int len = atom::getLen(s);
+            int len = atom::get_len(s);
             if (len < 0)
                 throw err_decode_exception("Error decoding ref's atom", idx+3);
             detail::check_node_length(len);

--- a/include/eixx/util/common.hpp
+++ b/include/eixx/util/common.hpp
@@ -31,7 +31,7 @@
 
 namespace eixx {
 
-#if BOOST_VERSION > 104800
+#if BOOST_VERSION >= 104800
 namespace bid = boost::interprocess::ipcdetail;
 #else
 namespace bid = boost::interprocess::detail;

--- a/src/basic_otp_node_local.cpp
+++ b/src/basic_otp_node_local.cpp
@@ -19,8 +19,6 @@ limitations under the License.
 */
 #include <boost/version.hpp>
 
-#if BOOST_VERSION < 106500
-
 #include <fstream>
 #include <sstream>
 #include <boost/asio.hpp>
@@ -126,5 +124,3 @@ void basic_otp_node_local::set_nodename(
 
 } // namespace connect
 } // namespace eixx
-
-#endif // BOOST_VERSION

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -12,8 +12,6 @@
 
 #include <boost/version.hpp>
 
-#if BOOST_VERSION < 106500
-
 #include <boost/asio.hpp>
 #include <string>
 #include <boost/noncopyable.hpp>
@@ -341,5 +339,3 @@ private:
 };
 
 } // namespace eixx
-
-#endif // BOOST_VERSION

--- a/src/test_node.cpp
+++ b/src/test_node.cpp
@@ -67,7 +67,7 @@ bool on_main_msg(otp_mailbox& a_mbox, eixx::transport_msg*& a_msg) {
         struct timeval tv =
             { l_binding[N1]->to_long() * 1000000 +
               l_binding[N2]->to_long(),
-              l_binding[N3]->to_long() };
+              static_cast<int>(l_binding[N3]->to_long()) };
         struct tm tm;
         localtime_r(&tv.tv_sec, &tm);
         printf(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,6 @@ target_link_libraries(
   eixx
   ${Erlang_EI_LIBRARIES}
   ${Boost_LIBRARIES}
-  boost_system
 )
 
 add_executable(test-perf test_perf.cpp)


### PR DESCRIPTION
Changes:
- [x] Support Boost v1.66+ (Fixes #41)
- [x] Support OTP v20 to v22 (Fixes #44) - Testing found `SMALL_ATOM_UTF8_EXT` is also used for pid's node.

